### PR TITLE
Blind counting sort

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ src/gist.rs
 src/one_hot_slot.rs
 
 PrivateKey*
+flamegraph.svg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-tfhe = { version = "0.5.0", features = [ "boolean", "shortint", "aarch64-unix" ] }
+tfhe = { version = "0.6.1", features = [ "boolean", "shortint", "aarch64-unix" ] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-tfhe = { version = "0.5.0", features = [ "boolean", "shortint", "x86_64-unix" ] }
+tfhe = { version = "0.6.1", features = [ "boolean", "shortint", "x86_64-unix" ] }
 
 [dependencies]
 num-complex = "0.4.0"
@@ -16,8 +16,8 @@ arrayvec = "0.7.2"
 aligned-vec = "0.5.0"
 rayon = "1.6.1"
 concrete-csprng = "0.4.0"
-dyn-stack = "0.9.0"
-itertools = "0.11.0"
+dyn-stack = "0.10.0"
+itertools = "0.13.0"
 concrete-fft = "0.4.0"
 bincode = "1.3.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -26,7 +26,7 @@ rand = "0.8"
 [dev-dependencies]
 quickcheck = "1"
 quickcheck_macros = "1"
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5.1", features = ["html_reports"] }
 
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
-tfhe = { version = "0.6.1", features = [ "boolean", "shortint", "aarch64-unix" ] }
+tfhe = { version = "0.6.1", features = ["boolean", "shortint", "aarch64-unix"] }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-tfhe = { version = "0.6.1", features = [ "boolean", "shortint", "x86_64-unix" ] }
+tfhe = { version = "0.6.1", features = ["boolean", "shortint", "x86_64-unix"] }
 
 [dependencies]
 num-complex = "0.4.0"
@@ -43,4 +43,8 @@ harness = false
 
 [[bench]]
 name = "bcs"
+harness = false
+
+[[bench]]
+name = "packing"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ harness = false
 [[bench]]
 name = "bp"
 harness = false
+
+[[bench]]
+name = "bcs"
+harness = false

--- a/benches/bcs.rs
+++ b/benches/bcs.rs
@@ -2,15 +2,17 @@ use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion
 use revolut::{key, random_lut, Context};
 use tfhe::shortint::parameters::*;
 
-fn bench_2bp(c: &mut Criterion, param: ClassicPBSParameters) {
-    let bitsize = param.message_modulus.0.ilog2() as usize;
-    c.bench_function(&format!("blindsort 2bp {}", bitsize), |b| {
+fn bench_bcs(c: &mut Criterion, param: ClassicPBSParameters) {
+    let size = param.message_modulus.0;
+    let bitsize = size.ilog2() as usize;
+    let private_key = key(param);
+    c.bench_function(&format!("blind counting sort {} bits", bitsize), |b| {
         b.iter_batched(
             || random_lut(param),
             |lut| {
-                key(param)
+                private_key
                     .public_key
-                    .blind_sort_2bp(black_box(lut), &Context::from(param))
+                    .blind_counting_sort(black_box(lut), &Context::from(param))
             },
             BatchSize::SmallInput,
         )
@@ -18,10 +20,10 @@ fn bench_2bp(c: &mut Criterion, param: ClassicPBSParameters) {
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    bench_2bp(c, PARAM_MESSAGE_2_CARRY_0);
-    bench_2bp(c, PARAM_MESSAGE_3_CARRY_0);
-    bench_2bp(c, PARAM_MESSAGE_4_CARRY_0);
-    bench_2bp(c, PARAM_MESSAGE_5_CARRY_0);
+    bench_bcs(c, PARAM_MESSAGE_2_CARRY_0);
+    bench_bcs(c, PARAM_MESSAGE_3_CARRY_0);
+    bench_bcs(c, PARAM_MESSAGE_4_CARRY_0);
+    bench_bcs(c, PARAM_MESSAGE_5_CARRY_0);
 }
 
 criterion_group! {

--- a/benches/bp.rs
+++ b/benches/bp.rs
@@ -34,6 +34,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     bench_bp(c, PARAM_MESSAGE_2_CARRY_0);
     bench_bp(c, PARAM_MESSAGE_3_CARRY_0);
     bench_bp(c, PARAM_MESSAGE_4_CARRY_0);
+    bench_bp(c, PARAM_MESSAGE_5_CARRY_0);
 }
 
 criterion_group! {

--- a/benches/packing.rs
+++ b/benches/packing.rs
@@ -1,0 +1,62 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use revolut::{key, Context};
+use tfhe::{
+    core_crypto::{
+        algorithms::{
+            par_private_functional_keyswitch_lwe_ciphertext_into_glwe_ciphertext,
+            par_private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext,
+        },
+        entities::{GlweCiphertext, LweCiphertextList},
+    },
+    shortint::parameters::*,
+};
+
+fn bench_packing(c: &mut Criterion, param: ClassicPBSParameters) {
+    let size = param.message_modulus.0;
+    let bitsize = size.ilog2() as usize;
+    let private_key = key(param);
+    let mut ctx = Context::from(param);
+    let lwe = private_key.allocate_and_encrypt_lwe(42, &mut ctx);
+    let lwe_ciphertext_list = LweCiphertextList::from_container(
+        lwe.clone().into_container(),
+        ctx.small_lwe_dimension().to_lwe_size(),
+        ctx.ciphertext_modulus(),
+    );
+    let mut glwe = GlweCiphertext::new(
+        0,
+        ctx.glwe_dimension().to_glwe_size(),
+        ctx.polynomial_size(),
+        ctx.ciphertext_modulus(),
+    );
+    c.bench_function(&format!("packing lwe {} bits", bitsize), |b| {
+        b.iter(|| {
+            par_private_functional_keyswitch_lwe_ciphertext_into_glwe_ciphertext(
+                &private_key.public_key.pfpksk,
+                &mut glwe,
+                &lwe,
+            )
+        })
+    });
+    c.bench_function(&format!("packing lwe list {} bits", bitsize), |b| {
+        b.iter(|| {
+            par_private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
+                &private_key.public_key.pfpksk,
+                &mut glwe,
+                &lwe_ciphertext_list,
+            )
+        })
+    });
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    bench_packing(c, PARAM_MESSAGE_2_CARRY_0);
+    bench_packing(c, PARAM_MESSAGE_3_CARRY_0);
+    bench_packing(c, PARAM_MESSAGE_4_CARRY_0);
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = criterion_benchmark
+}
+criterion_main!(benches);

--- a/src/blind_sort.rs
+++ b/src/blind_sort.rs
@@ -144,11 +144,11 @@ mod tests {
             let c_a = private_key.allocate_and_encrypt_lwe(a as u64, &mut ctx);
             for b in 0..ctx.message_modulus().0 {
                 let c_b = private_key.allocate_and_encrypt_lwe(b as u64, &mut ctx);
-                let begin = Instant::now();
+                // let begin = Instant::now();
                 let c_res = public_key.blind_lt(&c_a, &c_b, &ctx);
-                let elapsed = Instant::now() - begin;
-                println!("elapsed: {:?}", elapsed);
+                // let elapsed = Instant::now() - begin;
                 let res = private_key.decrypt_lwe(&c_res, &ctx);
+                // println!("{} < {} is {} ({}) ({:?})", a, b, res, res == 1, elapsed);
 
                 assert!(res == if a < b { 1 } else { 0 });
             }
@@ -160,15 +160,14 @@ mod tests {
         let mut ctx = Context::from(PARAM_MESSAGE_2_CARRY_0);
         let private_key = key(PARAM_MESSAGE_2_CARRY_0);
         let public_key = &private_key.public_key;
-        let array = vec![1, 3, 2, 2];
+        let array = vec![1, 2, 1, 0];
         let lut = LUT::from_vec(&array, &private_key, &mut ctx);
-        lut.print(&private_key, &ctx);
 
         let sorted_lut = public_key.blind_sort_bma(lut, &ctx);
         println!("sorted");
         sorted_lut.print(&private_key, &ctx);
 
-        let expected_array = vec![1, 2, 2, 3];
+        let expected_array = vec![0, 1, 1, 2];
         for i in 0..ctx.full_message_modulus {
             let lwe = public_key.sample_extract(&sorted_lut, i, &ctx);
             let actual = private_key.decrypt_lwe(&lwe, &ctx);
@@ -228,7 +227,6 @@ mod tests {
         let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
         let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
-        // private_key.debug_glwe("string", &sorted_lut.0, &ctx);
 
         let expected_array = vec![0, 0, 0, 0, 1, 1, 2, 3];
         for i in 0..array.len() {

--- a/src/blind_sort.rs
+++ b/src/blind_sort.rs
@@ -98,7 +98,7 @@ impl crate::PublicKey {
         // println!("counting values");
         for i in 0..n {
             let x = self.sample_extract(&lut, i, ctx);
-            self.blind_array_add(&mut count, &x, &one, ctx);
+            self.blind_array_add_trivial(&mut count, &x, 1, ctx);
         }
 
         // step 2: sort

--- a/src/blind_sort.rs
+++ b/src/blind_sort.rs
@@ -95,21 +95,21 @@ impl crate::PublicKey {
         let mut count = LUT::from_vec_trivially(&vec![0; n], ctx);
 
         // step 1: count values
-        println!("counting values");
+        // println!("counting values");
         for i in 0..n {
             let x = self.sample_extract(&lut, i, ctx);
             self.blind_array_add(&mut count, &x, &one, ctx);
         }
 
         // step 2: sort
-        println!("step 2: sorting");
+        // println!("step 2: sorting");
         let mut result = LUT::from_vec_trivially(&vec![0; n], ctx);
         let mut i = self.allocate_and_trivially_encrypt_lwe(0, ctx);
         let mut j = self.allocate_and_trivially_encrypt_lwe(0, ctx);
         let isnull = LUT::from_function(|v| if v == 0 { 1 } else { 0 }, ctx);
 
-        for idx in 0..2 * n {
-            println!("{}", idx);
+        for _idx in 0..2 * n {
+            // println!("{}", idx);
             let x = self.blind_array_access(&i, &count, ctx);
             let b = self.run_lut(&x, &isnull, ctx);
             let mut notb = one.clone();
@@ -225,19 +225,16 @@ mod tests {
         let public_key = &private_key.public_key;
         let array = vec![2, 1, 3, 1, 0, 0, 0, 0];
 
-        loop {
-            let lut = LUT::from_vec(&array, &private_key, &mut ctx);
+        let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
-            let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
-            private_key.debug_glwe("string", &sorted_lut.0, &ctx);
+        let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+        // private_key.debug_glwe("string", &sorted_lut.0, &ctx);
 
-            let expected_array = vec![0, 0, 0, 0, 1, 1, 2, 3];
-            for i in 0..array.len() {
-                let lwe = public_key.sample_extract(&sorted_lut, i, &ctx);
-                let actual = private_key.decrypt_lwe(&lwe, &ctx);
-                println!("{}", actual);
-                assert_eq!(actual, expected_array[i]);
-            }
+        let expected_array = vec![0, 0, 0, 0, 1, 1, 2, 3];
+        for i in 0..array.len() {
+            let lwe = public_key.sample_extract(&sorted_lut, i, &ctx);
+            let actual = private_key.decrypt_lwe(&lwe, &ctx);
+            assert_eq!(actual, expected_array[i]);
         }
     }
 }

--- a/src/blind_sort.rs
+++ b/src/blind_sort.rs
@@ -112,7 +112,7 @@ impl crate::PublicKey {
         // println!("counting values");
         for i in 0..n {
             let x = self.sample_extract(&lut, i, ctx);
-            self.blind_array_add_trivial(&mut count, &x, 1, ctx);
+            self.blind_array_inject_trivial(&mut count, &x, 1, ctx);
         }
         count.bootstrap(self, ctx);
 
@@ -130,9 +130,9 @@ impl crate::PublicKey {
             lwe_ciphertext_sub_assign(&mut notb, &b);
             let f = LUT::from_lwe(&i, &self, &ctx);
             let y = self.run_lut(&b, &f, ctx);
-            self.blind_array_add(&mut result, &j, &y, ctx);
+            self.blind_array_inject(&mut result, &j, &y, ctx);
             let minusnotb = self.neg_lwe(&notb, ctx);
-            self.blind_array_add(&mut count, &i, &minusnotb, ctx);
+            self.blind_array_inject(&mut count, &i, &minusnotb, ctx);
             count.bootstrap(self, ctx);
             lwe_ciphertext_add_assign(&mut i, &b);
             lwe_ciphertext_add_assign(&mut j, &notb);

--- a/src/blind_sort.rs
+++ b/src/blind_sort.rs
@@ -108,7 +108,7 @@ impl crate::PublicKey {
         let mut j = self.allocate_and_trivially_encrypt_lwe(0, ctx);
         let isnull = LUT::from_function(|v| if v == 0 { 1 } else { 0 }, ctx);
 
-        for idx in 0..2*n - 1 {
+        for idx in 0..2 * n {
             println!("{}", idx);
             let x = self.blind_array_access(&i, &count, ctx);
             let b = self.run_lut(&x, &isnull, ctx);
@@ -219,20 +219,25 @@ mod tests {
 
     #[test]
     fn test_blind_counting_sort() {
-        let param = PARAM_MESSAGE_4_CARRY_0;
+        let param = PARAM_MESSAGE_3_CARRY_0;
         let mut ctx = Context::from(param);
         let private_key = key(param);
         let public_key = &private_key.public_key;
-        let array = vec![3, 2, 1, 2];
-        let lut = LUT::from_vec(&array, &private_key, &mut ctx);
+        let array = vec![2, 1, 3, 1, 0, 0, 0, 0];
 
-        let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+        loop {
+            let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
-        let expected_array = vec![1, 2, 2, 3];
-        for i in 0..array.len() {
-            let lwe = public_key.sample_extract(&sorted_lut, i, &ctx);
-            let actual = private_key.decrypt_lwe(&lwe, &ctx);
-            assert_eq!(actual, expected_array[i]);
+            let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+            private_key.debug_glwe("string", &sorted_lut.0, &ctx);
+
+            let expected_array = vec![0, 0, 0, 0, 1, 1, 2, 3];
+            for i in 0..array.len() {
+                let lwe = public_key.sample_extract(&sorted_lut, i, &ctx);
+                let actual = private_key.decrypt_lwe(&lwe, &ctx);
+                println!("{}", actual);
+                assert_eq!(actual, expected_array[i]);
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1368,7 +1368,7 @@ impl LUT {
         );
 
         // Keyswitch and pack
-        private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
+        par_private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
             &public_key.pfpksk,
             &mut glwe,
             &lwe_ciphertext_list,
@@ -1441,7 +1441,7 @@ impl LUT {
         );
 
         // Keyswitch and pack
-        private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
+        par_private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
             &public_key.pfpksk,
             &mut glwe,
             &lwe_ciphertext_list,
@@ -1523,7 +1523,7 @@ impl LUT {
                 ctx.ciphertext_modulus(),
             );
             let redundancy_lwe = public_key.one_lwe_to_lwe_ciphertext_list(&lwe, ctx);
-            private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
+            par_private_functional_keyswitch_lwe_ciphertext_list_and_pack_in_glwe_ciphertext(
                 &public_key.pfpksk,
                 &mut glwe,
                 &redundancy_lwe,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,6 +1210,19 @@ impl PublicKey {
         blind_rotate_assign(&neg_i, &mut other.0, &self.fourier_bsk);
         self.glwe_sum_assign(&mut lut.0, &other.0);
     }
+
+    pub fn blind_array_add_trivial(
+        &self,
+        lut: &mut LUT,
+        i: &LweCiphertext<Vec<u64>>,
+        x: u64,
+        ctx: &Context,
+    ) {
+        let mut other = LUT::from_vec_trivially(&vec![x], ctx);
+        let neg_i = self.neg_lwe(i, ctx);
+        blind_rotate_assign(&neg_i, &mut other.0, &self.fourier_bsk);
+        self.glwe_sum_assign(&mut lut.0, &other.0);
+    }
 }
 
 pub struct LUT(pub GlweCiphertext<Vec<u64>>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1693,15 +1693,9 @@ impl LUT {
         );
     }
 
+    /// re-packs a fresh LUT from its sample extracts
     pub fn bootstrap(&self, public_key: &PublicKey, ctx: &Context) -> LUT {
-        // let n = self.0.polynomial_size().0 / ctx.box_size;
-        // let elements = Vec::from_iter((0..n).map(|i| public_key.sample_extract(self, i, ctx)));
         let many_lwe = self.to_many_lwe(public_key, ctx);
-        // let private_key = key(ctx.parameters);
-        // for (i, ciphertext) in many_lwe.iter().enumerate() {
-        //     let decrypted = private_key.decrypt_lwe(ciphertext, ctx);
-        //     println!("decrypted {}: {}", i, decrypted);
-        // }
         LUT::from_vec_of_lwe(many_lwe, public_key, ctx)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1275,8 +1275,9 @@ impl PublicKey {
         self.allocate_and_keyswitch_lwe_ciphertext(lwe, ctx)
     }
 
-    /// blindly adds x to the i-th coefficient of the given LUT
-    pub fn blind_array_add(
+    /// blindly adds x to the i-th box of the given LUT
+    /// this process is noisy and the LUT needs bootstrapping before being read
+    pub fn blind_array_inject(
         &self,
         lut: &mut LUT,
         i: &LweCiphertext<Vec<u64>>,
@@ -1289,7 +1290,7 @@ impl PublicKey {
         self.glwe_sum_assign(&mut lut.0, &other.0);
     }
 
-    pub fn blind_array_add_trivial(
+    pub fn blind_array_inject_trivial(
         &self,
         lut: &mut LUT,
         i: &LweCiphertext<Vec<u64>>,
@@ -2112,7 +2113,7 @@ mod test {
         let mut lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
         lut.print(&private_key, &ctx);
-        public_key.blind_array_add(&mut lut, &lwe_i, &lwe_x, &ctx);
+        public_key.blind_array_inject(&mut lut, &lwe_i, &lwe_x, &ctx);
         lut.print(&private_key, &ctx);
         array[i as usize] = (array[i as usize] + x) % size as u64;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,28 +37,31 @@
 
 // mod headers;
 
-// use std::fs;
+use std::{fs, time::Instant};
 
-use revolut::{key, Context, LUT};
+use revolut::*;
 use tfhe::shortint::parameters::*;
 
 // mod uni_test;
 // use uni_test::*;
 
+pub fn generate_keys() {
+    println!("generating keys and saving them to disk");
+    let mut ctx = Context::from(PARAM_MESSAGE_2_CARRY_0);
+    let private_key = PrivateKey::new(&mut ctx); // this takes time
+    let _ = fs::write("PrivateKey2", &bincode::serialize(&private_key).unwrap());
+    let mut ctx = Context::from(PARAM_MESSAGE_3_CARRY_0);
+    let private_key = PrivateKey::new(&mut ctx); // this takes time
+    let _ = fs::write("PrivateKey3", &bincode::serialize(&private_key).unwrap());
+    let mut ctx = Context::from(PARAM_MESSAGE_4_CARRY_0);
+    let private_key = PrivateKey::new(&mut ctx); // this takes time
+    let _ = fs::write("PrivateKey4", &bincode::serialize(&private_key).unwrap());
+    let mut ctx = Context::from(PARAM_MESSAGE_5_CARRY_0);
+    let private_key = PrivateKey::new(&mut ctx); // this takes time
+    let _ = fs::write("PrivateKey5", &bincode::serialize(&private_key).unwrap());
+}
+
 pub fn main() {
-    // println!("generating keys and saving them to disk");
-    // let mut ctx = Context::from(PARAM_MESSAGE_2_CARRY_0);
-    // let private_key = PrivateKey::new(&mut ctx); // this takes time
-    // let _ = fs::write("PrivateKey2", &bincode::serialize(&private_key).unwrap());
-    // let mut ctx = Context::from(PARAM_MESSAGE_3_CARRY_0);
-    // let private_key = PrivateKey::new(&mut ctx); // this takes time
-    // let _ = fs::write("PrivateKey3", &bincode::serialize(&private_key).unwrap());
-    // let mut ctx = Context::from(PARAM_MESSAGE_4_CARRY_0);
-    // let private_key = PrivateKey::new(&mut ctx); // this takes time
-    // let _ = fs::write("PrivateKey4", &bincode::serialize(&private_key).unwrap());
-    // let mut ctx = Context::from(PARAM_MESSAGE_5_CARRY_0);
-    // let private_key = PrivateKey::new(&mut ctx); // this takes time
-    // let _ = fs::write("PrivateKey5", &bincode::serialize(&private_key).unwrap());
     let param = PARAM_MESSAGE_4_CARRY_0;
     let mut ctx = Context::from(param);
     let private_key = key(param);
@@ -66,7 +69,11 @@ pub fn main() {
     let array = vec![3, 2, 1, 2];
     let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
-    let _ = public_key.blind_counting_sort(lut, &ctx);
+    let now = Instant::now();
+    let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+    println!("{:?}", Instant::now() - now);
+
+    sorted_lut.print(&private_key, &ctx);
 
     // test_blind_tensor_access();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,28 +37,36 @@
 
 // mod headers;
 
-use std::fs;
+// use std::fs;
 
-use revolut::{Context, PrivateKey};
-use tfhe::shortint::parameters::{PARAM_MESSAGE_2_CARRY_0, PARAM_MESSAGE_3_CARRY_0, PARAM_MESSAGE_4_CARRY_0, PARAM_MESSAGE_5_CARRY_0};
+use revolut::{key, Context, LUT};
+use tfhe::shortint::parameters::*;
 
 // mod uni_test;
 // use uni_test::*;
 
 pub fn main() {
-    println!("generating keys and saving them to disk");
-    let mut ctx = Context::from(PARAM_MESSAGE_2_CARRY_0);
-    let private_key = PrivateKey::new(&mut ctx); // this takes time
-    let _ = fs::write("PrivateKey2", &bincode::serialize(&private_key).unwrap());
-    let mut ctx = Context::from(PARAM_MESSAGE_3_CARRY_0);
-    let private_key = PrivateKey::new(&mut ctx); // this takes time
-    let _ = fs::write("PrivateKey3", &bincode::serialize(&private_key).unwrap());
-    let mut ctx = Context::from(PARAM_MESSAGE_4_CARRY_0);
-    let private_key = PrivateKey::new(&mut ctx); // this takes time
-    let _ = fs::write("PrivateKey4", &bincode::serialize(&private_key).unwrap());
-    let mut ctx = Context::from(PARAM_MESSAGE_5_CARRY_0);
-    let private_key = PrivateKey::new(&mut ctx); // this takes time
-    let _ = fs::write("PrivateKey5", &bincode::serialize(&private_key).unwrap());
+    // println!("generating keys and saving them to disk");
+    // let mut ctx = Context::from(PARAM_MESSAGE_2_CARRY_0);
+    // let private_key = PrivateKey::new(&mut ctx); // this takes time
+    // let _ = fs::write("PrivateKey2", &bincode::serialize(&private_key).unwrap());
+    // let mut ctx = Context::from(PARAM_MESSAGE_3_CARRY_0);
+    // let private_key = PrivateKey::new(&mut ctx); // this takes time
+    // let _ = fs::write("PrivateKey3", &bincode::serialize(&private_key).unwrap());
+    // let mut ctx = Context::from(PARAM_MESSAGE_4_CARRY_0);
+    // let private_key = PrivateKey::new(&mut ctx); // this takes time
+    // let _ = fs::write("PrivateKey4", &bincode::serialize(&private_key).unwrap());
+    // let mut ctx = Context::from(PARAM_MESSAGE_5_CARRY_0);
+    // let private_key = PrivateKey::new(&mut ctx); // this takes time
+    // let _ = fs::write("PrivateKey5", &bincode::serialize(&private_key).unwrap());
+    let param = PARAM_MESSAGE_4_CARRY_0;
+    let mut ctx = Context::from(param);
+    let private_key = key(param);
+    let public_key = &private_key.public_key;
+    let array = vec![3, 2, 1, 2];
+    let lut = LUT::from_vec(&array, &private_key, &mut ctx);
+
+    let _ = public_key.blind_counting_sort(lut, &ctx);
 
     // test_blind_tensor_access();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@
 
 // mod headers;
 
-use std::{fs, time::Instant};
+use std::fs;
 
 use revolut::*;
 use tfhe::shortint::parameters::*;
@@ -62,18 +62,19 @@ pub fn generate_keys() {
 }
 
 pub fn main() {
-    let param = PARAM_MESSAGE_4_CARRY_0;
-    let mut ctx = Context::from(param);
-    let private_key = key(param);
-    let public_key = &private_key.public_key;
-    let array = vec![3, 2, 1, 2];
-    let lut = LUT::from_vec(&array, &private_key, &mut ctx);
+    generate_keys();
+    // let param = PARAM_MESSAGE_4_CARRY_0;
+    // let mut ctx = Context::from(param);
+    // let private_key = key(param);
+    // let public_key = &private_key.public_key;
+    // let array = vec![3, 2, 1, 2];
+    // let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
-    let now = Instant::now();
-    let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
-    println!("{:?}", Instant::now() - now);
+    // let now = Instant::now();
+    // let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+    // println!("{:?}", Instant::now() - now);
 
-    sorted_lut.print(&private_key, &ctx);
+    // sorted_lut.print(&private_key, &ctx);
 
     // test_blind_tensor_access();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,24 +62,23 @@ pub fn generate_keys() {
 }
 
 pub fn main() {
-    generate_keys();
-    // let param = PARAM_MESSAGE_4_CARRY_0;
-    // let mut ctx = Context::from(param);
-    // let private_key = key(param);
-    // let public_key = &private_key.public_key;
-    // let array = vec![3, 2, 1, 2];
-    // let lut = LUT::from_vec(&array, &private_key, &mut ctx);
+    // generate_keys();
+    let param = PARAM_MESSAGE_4_CARRY_0;
+    let mut ctx = Context::from(param);
+    let private_key = key(param);
+    let public_key = &private_key.public_key;
+    let array = vec![3, 2, 1, 2];
+    let lut = LUT::from_vec(&array, &private_key, &mut ctx);
 
-    // let now = Instant::now();
-    // let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
-    // println!("{:?}", Instant::now() - now);
+    let now = std::time::Instant::now();
+    let sorted_lut = public_key.blind_counting_sort(lut, &ctx);
+    println!("{:?}", std::time::Instant::now() - now);
 
-    // sorted_lut.print(&private_key, &ctx);
+    sorted_lut.print(&private_key, &ctx);
 
     // test_blind_tensor_access();
 
     // test_blind_permutation();
-
     // blind_array_access(); // from blind_array_access
 
     // blind_array_access2d(); // from unitest_bacc2d


### PR DESCRIPTION
New algorithm based on the counting sort, scales linearly with the number of elements to sort.

- [x] blind_array_add
- [x] fix correctness
- [x] improve performance (LUT::from_lwe bottleneck)
  - [x] blind_array_inc (blind_array_add_trivial?) special case could be faster (use LUT::from_vec_trivially instead of LUT::from_lwe)
  - [x] improve LUT::from_lwe (parallelism? need tfhe 0.6)
  - [ ] ~replace LUT::from_lwe creation and evaluation by a cmux?~
- [x] investigate flakiness