### PR TITLE
wrapping_add to avoid overflow error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1039,7 +1039,7 @@ impl PublicKey {
         ct1.as_mut()
             .iter_mut()
             .zip(ct2.as_ref().iter())
-            .for_each(|(dst, &rhs)| *dst += rhs);
+            .for_each(|(dst, &rhs)| *dst = dst.wrapping_add(rhs));
     }
 
     pub fn glwe_sum_polynomial(&self, glwe: &GLWE, poly: &Poly, ctx: &Context) -> GLWE {


### PR DESCRIPTION
Adding wrapping_add to the PublicKey::glwe_sum_assign function to avoid "attempt to add with overflow"